### PR TITLE
Fix dicts.j2 templating issues

### DIFF
--- a/templates/dicts.j2
+++ b/templates/dicts.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!-- {{ ansible_managed }} -->
-<dictionaries>
+<yandex>
 {% for dict in clickhouse_dicts %}
   <dictionary>
     <name>{{ clickhouse_dicts[dict].name }}</name>
@@ -54,4 +54,4 @@
     </structure>
   </dictionary>
 {% endfor %}
-</dictionaries>
+</yandex>


### PR DESCRIPTION
It doesn't work with tag `<dictionaries>` in dictionaries include, according to official documentation it must begin with `<yandex>` tag https://clickhouse.tech/docs/en/sql-reference/dictionaries/external-dictionaries/external-dicts/